### PR TITLE
Refactored to work with docker-maven-plugin

### DIFF
--- a/microservice/catalog/pom.xml
+++ b/microservice/catalog/pom.xml
@@ -37,6 +37,36 @@
                     <skip>false</skip>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.jolokia</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>${version.docker-plugin}</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <alias>catalog</alias>
+                            <name>arungupta/shoppingcart-catalog</name>
+                            <build>
+                                <from>jboss/wildfly</from>
+                                <assembly>
+                                    <descriptor>assembly.xml</descriptor>
+                                    <basedir>/opt/jboss/wildfly/standalone/deployments</basedir>
+                                    <user>jboss:jboss:jboss</user>
+                                </assembly>
+                                <ports>
+                                    <port>8080</port>
+                                </ports>
+                            </build>
+                            <run>
+                                <ports>
+                                    <port>catalog.port:8080</port>
+                                </ports>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/microservice/catalog/src/main/docker/assembly.xml
+++ b/microservice/catalog/src/main/docker/assembly.xml
@@ -7,7 +7,6 @@
             <includes>
                 <include>org.javaee7.wildfly.samples:catalog</include>
             </includes>
-            <outputDirectory>/opt/jboss/wildfly/standalone/deployments/</outputDirectory>
             <outputFileNameMapping>catalog.war</outputFileNameMapping>
         </dependencySet>
     </dependencySets>

--- a/microservice/everest/pom.xml
+++ b/microservice/everest/pom.xml
@@ -45,6 +45,36 @@
                     <skip>false</skip>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.jolokia</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>${version.docker-plugin}</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <alias>everest-web</alias>
+                            <name>arungupta/shoppingcart-web</name>
+                            <build>
+                                <from>jboss/wildfly</from>
+                                <assembly>
+                                    <descriptor>assembly.xml</descriptor>
+                                    <basedir>/opt/jboss/wildfly/standalone/deployments</basedir>
+                                    <user>jboss:jboss:jboss</user>
+                                </assembly>
+                                <ports>
+                                    <port>8080</port>
+                                </ports>
+                            </build>
+                            <run>
+                                <ports>
+                                    <port>web.port:8080</port>
+                                </ports>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/microservice/everest/src/main/docker/assembly.xml
+++ b/microservice/everest/src/main/docker/assembly.xml
@@ -5,9 +5,9 @@
     <dependencySets>
         <dependencySet>
             <includes>
-                <include>org.javaee7.wildfly.samples:order</include>
+                <include>org.javaee7.wildfly.samples:everest-web</include>
             </includes>
-            <outputFileNameMapping>order.war</outputFileNameMapping>
+            <outputFileNameMapping>everest.war</outputFileNameMapping>
         </dependencySet>
     </dependencySets>
 </assembly>

--- a/microservice/order/pom.xml
+++ b/microservice/order/pom.xml
@@ -37,6 +37,37 @@
                     <skip>false</skip>
                 </configuration>
             </plugin>
+
+            <plugin>
+               <groupId>org.jolokia</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>${version.docker-plugin}</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <alias>order</alias>
+                            <name>arungupta/shoppingcart-order</name>
+                            <build>
+                                <from>jboss/wildfly</from>
+                                <assembly>
+                                    <descriptor>assembly.xml</descriptor>
+                                    <basedir>/opt/jboss/wildfly/standalone/deployments</basedir>
+                                    <user>jboss:jboss:jboss</user>
+                                </assembly>
+                                <ports>
+                                    <port>8080</port>
+                                </ports>
+                            </build>
+                            <run>
+                                <ports>
+                                    <port>order.port:8080</port>
+                                </ports>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -21,7 +21,7 @@
     
     <properties>
         <version.wildfly-swarm>1.0.0.Alpha1</version.wildfly-swarm>
-        <version.docker-plugin>0.11.3</version.docker-plugin>
+        <version.docker-plugin>0.12.1-SNAPSHOT</version.docker-plugin>
         <version.resteasy>3.0.11.Final</version.resteasy>
         <version.curator>2.8.0</version.curator>        
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -110,6 +110,12 @@
                         <failOnMissingWebXml>false</failOnMissingWebXml>
                     </configuration>
                 </plugin>
+
+                <plugin>
+                    <groupId>org.jolokia</groupId>
+                    <artifactId>docker-maven-plugin</artifactId>
+                    <version>${version.docker-plugin}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -147,92 +153,7 @@
                     <plugin>
                         <groupId>org.jolokia</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.11.5</version>
-                        <configuration>
-                            <images>
-                                <image>
-                                    <alias>user</alias>
-                                    <name>arungupta/shoppingcart-user</name>
-                                    <build>
-                                        <from>jboss/wildfly</from>
-                                        <assembly>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <basedir>user</basedir>
-                                        </assembly>
-                                        <ports>
-                                            <port>8080</port>
-                                        </ports>
-                                    </build>
-                                    
-                                    <run>
-                                        <ports>
-                                            <port>user.port:8080</port>
-                                        </ports>
-                                    </run>
-                                </image>
-                                <image>
-                                    <alias>catalog</alias>
-                                    <name>arungupta/shoppingcart-catalog</name>
-                                    <build>
-                                        <from>jboss/wildfly</from>
-                                        <assembly>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <basedir>catalog</basedir>
-                                        </assembly>
-                                        <ports>
-                                            <port>8080</port>
-                                        </ports>
-                                    </build>
-
-                                    <run>
-                                        <ports>
-                                            <port>user.port:8080</port>
-                                        </ports>
-                                    </run>
-                                </image>
-                                <image>
-                                    <alias>order</alias>
-                                    <name>arungupta/shoppingcart-order</name>
-                                    <build>
-                                        <from>jboss/wildfly</from>
-                                        <assembly>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <basedir>order</basedir>
-                                        </assembly>
-                                        <ports>
-                                            <port>8080</port>
-                                        </ports>
-                                    </build>
-
-                                    <run>
-                                        <ports>
-                                            <port>user.port:8080</port>
-                                        </ports>
-                                    </run>
-                                </image>
-                                <image>
-                                    <alias>everest-web</alias>
-                                    <name>arungupta/shoppingcart-web</name>
-                                    <build>
-                                        <from>jboss/wildfly</from>
-                                        <assembly>
-                                            <descriptor>assembly.xml</descriptor>
-                                            <basedir>everest-web</basedir>
-                                        </assembly>
-                                        <ports>
-                                            <port>8080</port>
-                                        </ports>
-                                    </build>
-
-                                    <run>
-                                        <ports>
-                                            <port>user.port:8080</port>
-                                        </ports>
-                                    </run>
-                                </image>
-                            </images>
-                        </configuration>
-                        
+                        <version>${version.docker-plugin}</version>
                         <executions>
                             <execution>
                                 <id>docker:build</id>

--- a/microservice/user/pom.xml
+++ b/microservice/user/pom.xml
@@ -37,6 +37,37 @@
                     <skip>false</skip>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.jolokia</groupId>
+                <artifactId>docker-maven-plugin</artifactId>
+                <version>${version.docker-plugin}</version>
+                <configuration>
+                    <images>
+                        <image>
+                            <alias>user</alias>
+                            <name>arungupta/shoppingcart-user</name>
+                            <build>
+                                <from>jboss/wildfly</from>
+                                <assembly>
+                                    <descriptor>assembly.xml</descriptor>
+                                    <basedir>/opt/jboss/wildfly/standalone/deployments</basedir>
+                                    <user>jboss:jboss:jboss</user>
+                                </assembly>
+                                <ports>
+                                    <port>8080</port>
+                                </ports>
+                            </build>
+                            <run>
+                                <ports>
+                                    <port>user.port:8080</port>
+                                </ports>
+                            </run>
+                        </image>
+                    </images>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
+
 </project>

--- a/microservice/user/src/main/docker/assembly.xml
+++ b/microservice/user/src/main/docker/assembly.xml
@@ -7,7 +7,6 @@
             <includes>
                 <include>org.javaee7.wildfly.samples:user</include>
             </includes>
-            <outputDirectory>/opt/jboss/wildfly/standalone/deployments/</outputDirectory>
             <outputFileNameMapping>user.war</outputFileNameMapping>
         </dependencySet>
     </dependencySets>


### PR DESCRIPTION
The docker plugin configuration has been moved to the subprojects and
the configuration adapted accordingly.

If no linking is required between Docker containers, the prefered way
to configure this plugin is within submodules. Currently there is
quite some redundancy, this is currently unavoidable. Latter on the
dmp might be enhanced to allow for some templating in the
configuration.

Some remarks about the base image jboss/wildfly:
- It's quite bloated. For a Mircorservice base image serving as runtim
  it shouldn't contain exampls and documentation.
- Since it is assumed to runder a fix user id "jboss" problem will
  arise within a OpenShift since there a container is run by default
  under a random UID for security reason. The problem will be that
  this random user is not allowed to write in the deployment
  directory
  See here for more about information about the OpenShift decision:
  https://docs.openshift.org/latest/creating_images/guidelines.html#openshift-specific-guidelines
- The admin console doesn't work since it doesn't seem to be prepared
  to be run within a Docker image

I had to make some minor fixes for the Docker Maven Plugin, since up
to now it was not tested very well in a multi-module-project. So
currently 0.12.1-SNAPSHOT is used, but I will make a release at the
end of this week for 0.12.1

The configuration of the plugin also has been moved out of the
profile, since it doesn't harm anyway. I left the binding to execution
phases in the profile, though.

You can now build the images with

```
mvn package docker:build
```

(package is required because of a Maven limitation, otherwise the
assembly can't find its artefact) and start it with

```
mvn docker:start
```

This can be done also in a single subproject. A new, quite cool
feature is 'mvn docker:watch' so when you call

```
mvn clean package docker:build docker:start docker:watch
```

in one terminal (it will block) and then change and compile any
subproject, the Docker image will automatically be rebuilt and
restarted. This only works from within a subproject and not top-level
because it blocks.
