### PR TITLE
Add defaut docker command for all images

### DIFF
--- a/microservice/pom.xml
+++ b/microservice/pom.xml
@@ -236,6 +236,21 @@
                                 <goals>
                                     <goal>build</goal>
                                 </goals>
+                                <configuration>
+                                    <images>
+                                        <image>
+                                            <build combine.self="append">
+                                                <cmd>
+                                                    <exec>
+                                                        <args>/opt/jboss/wildfly/bin/standalone.sh</args>
+                                                        <args>-b</args>
+                                                        <args>127.0.0.1</args>
+                                                    </exec>
+                                                </cmd>
+                                            </build>
+                                        </image>
+                                    </images>
+                                </configuration>
                             </execution>
                             <execution>
                                 <id>docker:start</id>


### PR DESCRIPTION
For your simple, quite homogenous setup this PR can be used to set the default command for all images in the parent pom. 
